### PR TITLE
Add no_std support with optional alloc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,12 @@ description = "hypher separates words into syllables."
 repository = "https://github.com/typst/hypher"
 readme = "README.md"
 license = "MIT OR Apache-2.0"
-categories = ["text-processing", "internationalization"]
+categories = ["text-processing", "internationalization", "no-std"]
 keywords = ["hyphenation", "syllables"]
 
 [features]
-default = ["full"]
+default = ["alloc", "full"]
+alloc =[]
 full = [
     "afrikaans",
     "albanian",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["hyphenation", "syllables"]
 
 [features]
 default = ["alloc", "full"]
-alloc =[]
+alloc = []
 full = [
     "afrikaans",
     "albanian",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ hypher = { version = "0.1", default-features = false, features = ["english"] }
 ```
 */
 
-#![cfg_attr(not(test), no_std)]
+#![no_std]
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,20 @@ assert_eq!(syllables.next(), Some("ten"));
 assert_eq!(syllables.next(), Some("sive"));
 assert_eq!(syllables.next(), None);
 ```
-
+*/
+#![cfg_attr(
+    feature = "alloc",
+    doc = r##"
+If the `alloc` feature is enabled, you can use [`Syllables::join`] to create
+a new string.
+```rust
+# use hypher::{hyphenate, Lang};
+let mut syllables = hyphenate("extensive", Lang::English);
+assert_eq!(syllables.join("-"), "ex-ten-sive");
+```
+"##
+)]
+/*!
 # Languages
 By default, this crate supports hyphenating more than 30 languages. Embedding
 automata for all these languages will add ~1.1 MB to your binary. Alternatively,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,6 @@ hypher = { version = "0.1", default-features = false, features = ["english"] }
 #![deny(missing_docs)]
 
 #[cfg(any(feature = "alloc", test))]
-#[cfg_attr(not(test), macro_use)]
 extern crate alloc;
 
 use core::fmt::{self, Debug, Formatter};
@@ -265,7 +264,7 @@ impl Bytes {
         } else {
             #[cfg(feature = "alloc")]
             {
-                Self::Vec(vec![0; len].into_iter())
+                Self::Vec(alloc::vec![0; len].into_iter())
             }
             #[cfg(not(feature = "alloc"))]
             {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -269,7 +269,7 @@ impl Bytes {
             }
             #[cfg(not(feature = "alloc"))]
             {
-                panic!("Word too large")
+                panic!("word too long");
             }
         }
     }


### PR DESCRIPTION
When the `alloc` feature is disabled, very large words will cause a panic instead of an allocation on the heap, and the `syllables::join` method is disabled. Everything else works exactly the same.

The doc-tests can't use `syllables::join` anymore, so they are a bit noisier. [`itertools::assert_equal`](https://docs.rs/itertools/latest/itertools/fn.assert_equal.html) would help with this, if you are comfortable with adding that as a dev-dependency.

Future possibilities:
- A function that returns an error instead of panicking
- A way to configure the maximum word size with const generics