### PR TITLE
Add hyphenation_character method to Lang

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ hypher = "0.1"
   disable the `alloc` feature, but then overly long words lead to a panic.
 - Support for many languages.
 - No unsafe code, no dependencies, no std.
+- Hyphenation character awareness: `Lang::hyphenation_character()` returns
+  `None` for Indic scripts where visual hyphenation is not conventional.
 
 ## Example
 ```rust

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -368,6 +368,40 @@ impl Lang {
         }
     }
 
+    /// The default character used to join syllables.
+    ///
+    /// Returns `Some('\u{ad}')` (SOFT HYPHEN) for most languages, but `None`
+    /// for Indic scripts where visual hyphenation is not conventional.
+    pub fn hyphenation_character(self) -> Option<char> {
+        match self {
+            #[cfg(feature = "assamese")]
+            Self::Assamese => None,
+            #[cfg(feature = "bengali")]
+            Self::Bengali => None,
+            #[cfg(feature = "gujarati")]
+            Self::Gujarati => None,
+            #[cfg(feature = "hindi")]
+            Self::Hindi => None,
+            #[cfg(feature = "kannada")]
+            Self::Kannada => None,
+            #[cfg(feature = "malayalam")]
+            Self::Malayalam => None,
+            #[cfg(feature = "marathi")]
+            Self::Marathi => None,
+            #[cfg(feature = "oriya")]
+            Self::Oriya => None,
+            #[cfg(feature = "panjabi")]
+            Self::Panjabi => None,
+            #[cfg(feature = "sanskrit")]
+            Self::Sanskrit => None,
+            #[cfg(feature = "tamil")]
+            Self::Tamil => None,
+            #[cfg(feature = "telugu")]
+            Self::Telugu => None,
+            _ => Some('\u{ad}'),
+        }
+    }
+
     fn root(self) -> State<'static> {
         match self {
             #[cfg(feature = "afrikaans")]

--- a/tests/generate.rs
+++ b/tests/generate.rs
@@ -160,6 +160,30 @@ fn write_lang(
     writeln!(w, "    }}")?;
     writeln!(w)?;
 
+    // Implementation of `hyphenation_character`.
+    writeln!(w, "    /// The default character used to join syllables.")?;
+    writeln!(w, "    ///")?;
+    writeln!(w, "    /// Returns `Some('\\u{{ad}}')` (SOFT HYPHEN) for most languages, but `None`")?;
+    writeln!(
+        w,
+        "    /// for Indic scripts where visual hyphenation is not conventional."
+    )?;
+    writeln!(w, "    pub fn hyphenation_character(self) -> Option<char> {{")?;
+    writeln!(w, "        match self {{")?;
+    for &(name, _, _, script, ..) in languages {
+        if !is_indic_script(script) {
+            continue;
+        }
+        let feature = name.to_lowercase();
+        write!(w, "            ")?;
+        write_cfg(w, &feature)?;
+        writeln!(w, "            Self::{name} => None,")?;
+    }
+    writeln!(w, "            _ => Some('\\u{{ad}}'),")?;
+    writeln!(w, "        }}")?;
+    writeln!(w, "    }}")?;
+    writeln!(w)?;
+
     // Implementation of `root`.
     writeln!(w, "    fn root(self) -> State<'static> {{")?;
     writeln!(w, "        match self {{")?;
@@ -173,6 +197,14 @@ fn write_lang(
     writeln!(w, "        }}")?;
     writeln!(w, "    }}")?;
     writeln!(w, "}}")
+}
+
+/// Returns true for Indic scripts where visual hyphenation is not conventional.
+fn is_indic_script(script: &str) -> bool {
+    matches!(
+        script,
+        "Beng" | "Deva" | "Gujr" | "Guru" | "Knda" | "Mlym" | "Orya" | "Taml" | "Telu"
+    )
 }
 
 fn write_cfg(w: &mut String, feature: &str) -> fmt::Result {


### PR DESCRIPTION
Add hyphenation_character method to Lang so that typst can use Hypher for patterns and  properties like bounds, hyphenation_character. Any downstream users of Hypher library can also use these characters at presentation layer.

Refer discussion at: https://github.com/typst/typst/issues/8033 and https://github.com/typst/hypher/pull/30


Following is a screenshot from typst after integrating this feature. PR for typst is coming soon. You can see that words are broken at line ends as per hyphenation rules without visible hyphen as expected. For English, hyphens are visible

<img width="735" height="1019" alt="image" src="https://github.com/user-attachments/assets/07f8834c-46e3-4b08-97f1-43e83b10bb58" />
